### PR TITLE
Update EC2 Instance Type & Fix the Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ cdk deploy devNitroWalletEth -O output.json
 
 After the `output.json` file has been created, the following command can be used to create the KMS key policy:
 ```bash
-./script/generate_key_policy.sh ./output.json
+./scripts/generate_key_policy.sh ./output.json
 ```
 
 If the debug mode has been turned on by appending `--debug-mode` to the enclaves start sequence, the enclaves PCR0 value in the AWS KMS key policy needs to be updated to `000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`,

--- a/nitro_wallet/nitro_wallet_stack.py
+++ b/nitro_wallet/nitro_wallet_stack.py
@@ -170,7 +170,7 @@ class NitroWalletStack(Stack):
         nitro_launch_template = aws_ec2.LaunchTemplate(
             self,
             "NitroEC2LauchTemplate",
-            instance_type=aws_ec2.InstanceType("m5a.xlarge"),
+            instance_type=aws_ec2.InstanceType("m6i.xlarge"),
             user_data=aws_ec2.UserData.custom(user_data_raw),
             nitro_enclave_enabled=True,
             machine_image=amzn_linux,

--- a/nitro_wallet/nitro_wallet_stack.py
+++ b/nitro_wallet/nitro_wallet_stack.py
@@ -167,10 +167,11 @@ class NitroWalletStack(Stack):
         signing_server_image.repository.grant_pull(role)
         encrypted_key.grant_read(role)
 
+        #For some regions (e.g. Hong Kong ap-east-1) can use m6i.xlarge EC2 instances to replace
         nitro_launch_template = aws_ec2.LaunchTemplate(
             self,
             "NitroEC2LauchTemplate",
-            instance_type=aws_ec2.InstanceType("m6i.xlarge"),
+            instance_type=aws_ec2.InstanceType("m5a.xlarge"), 
             user_data=aws_ec2.UserData.custom(user_data_raw),
             nitro_enclave_enabled=True,
             machine_image=amzn_linux,

--- a/nitro_wallet/nitro_wallet_stack.py
+++ b/nitro_wallet/nitro_wallet_stack.py
@@ -167,11 +167,10 @@ class NitroWalletStack(Stack):
         signing_server_image.repository.grant_pull(role)
         encrypted_key.grant_read(role)
 
-        #For some regions (e.g. Hong Kong ap-east-1) can use m6i.xlarge EC2 instances to replace
         nitro_launch_template = aws_ec2.LaunchTemplate(
             self,
             "NitroEC2LauchTemplate",
-            instance_type=aws_ec2.InstanceType("m5a.xlarge"), 
+            instance_type=aws_ec2.InstanceType("m6i.xlarge"),
             user_data=aws_ec2.UserData.custom(user_data_raw),
             nitro_enclave_enabled=True,
             machine_image=amzn_linux,


### PR DESCRIPTION
The changes:
    - Changed the EC2 Instance Type (m5a.xlarge -> m6i.xlarge)
    - Changed the generate_key_policy.sh
        - Because of the error: `jq: error: Top-level program not given (try ".") jq: 1 compile error`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
