### PR TITLE
Fixed insufficent privileges issue

### DIFF
--- a/user_data/user_data.sh
+++ b/user_data/user_data.sh
@@ -201,5 +201,5 @@ cd /etc/pki/tls/certs
 ./make-dummy-cert localhost.crt
 
 # docker over system process manager
-docker run -d --restart unless-stopped --name http_server -v /etc/pki/tls/certs/:/etc/pki/tls/certs/ -p 443:443 ${__SIGNING_SERVER_IMAGE_URI__}
+docker run -d --restart unless-stopped --security-opt seccomp=unconfined --name http_server -v /etc/pki/tls/certs/:/etc/pki/tls/certs/ -p 443:443 ${__SIGNING_SERVER_IMAGE_URI__}
 --//--


### PR DESCRIPTION
* Fixed insufficient privileges issue accessing `/dev/vsock` from inside docker container. Certain syscalls are blocked per default. Using `--security-opt seccomp=unconfined` to remove syscall restriction.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
