### PR TITLE
Removed application type variable in kmstool-enclave-cli path

### DIFF
--- a/scripts/build_kmstool_enclave_cli.sh
+++ b/scripts/build_kmstool_enclave_cli.sh
@@ -6,7 +6,7 @@ set +x
 set -e
 
 NITRO_ENCLAVE_CLI_VERSION="v0.4.1"
-KMS_FOLDER="./application/${CDK_APPLICATION_TYPE}/enclave/kms"
+KMS_FOLDER="./application/eth1/enclave/kms"
 KMSTOOL_FOLDER="./aws-nitro-enclaves-sdk-c/bin/kmstool-enclave-cli"
 TARGET_PLATFORM="linux/amd64"
 


### PR DESCRIPTION
Removed path variable for `kmstool-enclave-cli` to stay consistent with AWS Nitro Wallet Workshop (https://catalog.workshops.aws/nitrowallet)

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
