### PR TITLE
Bumped kmstool cli to v0.4.3 to unblock build

### DIFF
--- a/scripts/build_kmstool_enclave_cli.sh
+++ b/scripts/build_kmstool_enclave_cli.sh
@@ -5,7 +5,7 @@
 set +x
 set -e
 
-NITRO_ENCLAVE_CLI_VERSION="v0.4.1"
+NITRO_ENCLAVE_CLI_VERSION="v0.4.3"
 KMS_FOLDER="./application/eth1/enclave/kms"
 KMSTOOL_FOLDER="./aws-nitro-enclaves-sdk-c/bin/kmstool-enclave-cli"
 TARGET_PLATFORM="linux/amd64"


### PR DESCRIPTION
Closes #34 

*Description of changes:*
* Updated kmstool-enclave-cli version to v0.4.3 unblock build script


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
